### PR TITLE
Fix v_max and a_max parameters

### DIFF
--- a/pyscurve/scurve.py
+++ b/pyscurve/scurve.py
@@ -416,15 +416,15 @@ class ScurvePlanner(TrajectoryPlanner):
             # the longest execution time
             if _v1 != 0:
                 traj_params =\
-                    self.__plan_trajectory_1D(_q0, _q1, _v0, _v1, a_max,
-                                              v_max, j_max,
+                    self.__plan_trajectory_1D(_q0, _q1, _v0, _v1, v_max,
+                                              a_max, j_max,
                                               T=max_displacement_time)
 
             # if final velocity is zero we do not need to worry about
             # syncronization
             else:
                 traj_params = self.__plan_trajectory_1D(_q0, _q1, _v0, _v1,
-                                                        a_max, v_max, j_max)
+                                                        v_max, a_max, j_max)
 
             T[ii] = Ta[ii] + Td[ii] + Tv[ii]
             self.__put_params(trajectory_params, traj_params, ii)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='pyscurve',
-    version='1.0',
+    version='1.0.1',
     packages=find_packages(),
     install_requires=['numpy', 'matplotlib']
 )


### PR DESCRIPTION
Fix issues #6 and #7. As noted on #6, the parameters were called in the wrong order on lines 419 and 426 of `scurve_py`. So far my tests have behaved accordingly and I believe the issue has been fixed.