### PR TITLE
Edge cases where coordinates are same

### DIFF
--- a/license
+++ b/license
@@ -1,4 +1,5 @@
 Copyright (c) 2017 Kamnev Iurii
+Copyright (c) 2022 Ibrahim Ahmed
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/pyscurve/scurve.py
+++ b/pyscurve/scurve.py
@@ -5,7 +5,8 @@ from .planner import TrajectoryPlanner
 import logging
 
 
-logging.basicConfig(format='%(message)s', level=logging.DEBUG)
+# Elevated from DEBUG to WARNING logger was putting out lots of debug messages
+logging.basicConfig(format='%(message)s', level=logging.WARNING)
 
 planning_logger = logging.getLogger(__name__)
 
@@ -333,8 +334,8 @@ class ScurvePlanner(TrajectoryPlanner):
                                              j_max)
 
         planning_logger.info("Planning trajectory with given parameters")
-        planning_logger.info("%f %f %f %f %f %f %f" %
-                             (q0, q1, v0, v1, v_max, a_max, j_max) +
+        planning_logger.info("q0:%f q1:%f v0:%f v1:%f \nv_max:%f a_max:%f j_max:%f" %
+                             (q0, q1, v0, v1, v_max, a_max, j_max) + ' T:' +
                              str(T))
         planning_logger.debug("Sign transform result")
         planning_logger.debug("{} {} {} {} {} {} {}".format(*zipped_args))
@@ -407,6 +408,14 @@ class ScurvePlanner(TrajectoryPlanner):
 
         for _q0, _q1, _v0, _v1, ii in zip(q0, q1, v0, v1, range(ndof)):
             if ii == max_displacement_id:
+                continue
+            # this axis on the waypoint is the same, therefore zero acceleration
+            # needed
+            elif _q0==_q1:
+                # If there is no change in coordinate, then there should be no
+                # change in velocity.
+                if _v0 != 0 or _v1!=0:
+                    raise PlanningError('Waypoint coordinate is same, but velocity is non-zero.')
                 continue
 
             planning_logger.info("Computing %d DOF trajectory" % ii)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='pyscurve',
-    version='1.0.1',
+    version='1.0.2',
     packages=find_packages(),
     install_requires=['numpy', 'matplotlib']
 )


### PR DESCRIPTION
In this pull request, I made the following changes.

1. Edge cases where coordinates are the same. For example, if a trajectory is being planned for [0,1] to [0,3], then zero velocity/acceleration are needed along the first axis.

2. Verbosity of log messages. I changed default logging level from `DEBUG` to `WARNING` to reduce amount of stdout messages. The users can manually change logger verbosity to print debug messages when needed.

3. Bumped version number to 1.0.2 to reflect these patches.